### PR TITLE
Add digital certificate authentication flows

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,19 @@ from werkzeug.security import generate_password_hash
 from PIL import Image
 from config import Config
 from flask_cors import CORS
-from models import Archivo, Etiqueta, Usuario, db, archivo_etiqueta, favoritos, Playlist, playlist_archivo, Bloc, bloc_compartido
+from models import (
+    Archivo,
+    Etiqueta,
+    Usuario,
+    db,
+    archivo_etiqueta,
+    favoritos,
+    Playlist,
+    playlist_archivo,
+    Bloc,
+    bloc_compartido,
+    CertificadoDigital,
+)
 from utils import (
     guardar_miniatura_si_es_imagen,
     convertir_doc_a_pdf,
@@ -52,6 +64,20 @@ db.init_app(app)
 
 app.register_blueprint(api_bp)
 
+AVATARES_DISPONIBLES = [
+    {"valor": "default_avatar.png", "etiqueta": "🐉 Default"},
+    {"valor": "dragon.png", "etiqueta": "🔥 Dragón"},
+    {"valor": "hielo.png", "etiqueta": "❄️ Hielo"},
+    {"valor": "sombra.png", "etiqueta": "🌑 Sombra"},
+]
+
+AUTH_STATIC_FOLDER = os.path.join(app.root_path, 'static')
+
+
+@app.route('/assets/<path:filename>')
+def serve_design_asset(filename):
+    return send_from_directory(AUTH_STATIC_FOLDER, filename)
+
 # Crear tablas al iniciar si no existen
 with app.app_context():
     db.create_all()
@@ -82,7 +108,7 @@ def registro():
         flash("✅ Usuario registrado correctamente.")
         return redirect(url_for('login'))
 
-    return render_template('registro.html')
+    return render_template('registro.html', avatars=AVATARES_DISPONIBLES)
 
 @app.route('/login', methods=['GET', 'POST'])
 def login():
@@ -104,6 +130,82 @@ def login():
             flash("❌ Usuario o contraseña incorrectos.")
 
     return render_template('login.html')
+
+
+@app.route('/login/certificado', methods=['GET', 'POST'])
+def login_certificado():
+    if request.method == 'POST':
+        numero_serie = request.form['numero_serie'].strip()
+        clave_privada = request.form['clave_privada']
+
+        certificado = CertificadoDigital.query.filter_by(numero_serie=numero_serie).first()
+        if certificado and certificado.verificar_clave(clave_privada):
+            usuario = certificado.usuario
+            session['usuario_id'] = usuario.id
+            session['usuario_nombre'] = usuario.nombre
+            session['avatar'] = usuario.avatar
+            session['es_admin'] = usuario.es_admin
+            session['acceso_privado'] = usuario.acceso_privado
+
+            flash(f"✅ Certificado verificado. ¡Bienvenido, {usuario.nombre}!")
+            return redirect(url_for('ver_archivos'))
+
+        flash("❌ Certificado o contraseña privada no válidos.")
+
+    return render_template('login_certificado.html')
+
+
+@app.route('/registro/certificado', methods=['GET', 'POST'])
+def registro_certificado():
+    if request.method == 'POST':
+        nombre = request.form['nombre'].strip().lower()
+        numero_serie = request.form['numero_serie'].strip()
+        alias = request.form.get('alias', '').strip() or None
+        clave_privada = request.form['clave_privada']
+        contraseña_local = request.form.get('contraseña_local', '').strip()
+        avatar = request.form.get('avatar', 'default_avatar.png')
+        acceso_privado = bool(request.form.get('acceso_privado'))
+
+        if CertificadoDigital.query.filter_by(numero_serie=numero_serie).first():
+            flash("❌ Ese certificado ya está registrado en DovahCloud.")
+            return redirect(url_for('registro_certificado'))
+
+        usuario = Usuario.query.filter_by(nombre=nombre).first()
+
+        if usuario is None:
+            if not contraseña_local:
+                flash("⚠️ Debes definir una contraseña local para crear una cuenta nueva.")
+                return redirect(url_for('registro_certificado'))
+
+            usuario = Usuario(
+                nombre=nombre,
+                avatar=avatar,
+                acceso_privado=acceso_privado,
+            )
+            usuario.establecer_contraseña(contraseña_local)
+            db.session.add(usuario)
+            db.session.flush()
+        else:
+            if contraseña_local:
+                usuario.establecer_contraseña(contraseña_local)
+            usuario.acceso_privado = usuario.acceso_privado or acceso_privado
+            if avatar:
+                usuario.avatar = avatar
+
+        certificado = CertificadoDigital(
+            usuario=usuario,
+            numero_serie=numero_serie,
+            alias=alias,
+        )
+        certificado.establecer_clave(clave_privada)
+
+        db.session.add(certificado)
+        db.session.commit()
+
+        flash("✅ Certificado registrado correctamente. Ya puedes iniciar sesión con él.")
+        return redirect(url_for('login_certificado'))
+
+    return render_template('registro_certificado.html', avatars=AVATARES_DISPONIBLES)
 
 @app.route('/logout')
 def logout():

--- a/models.py
+++ b/models.py
@@ -66,6 +66,23 @@ class Usuario(db.Model, UserMixin):
     def verificar_contraseña(self, contraseña_clara):
         return check_password_hash(self.contraseña_hash, contraseña_clara)
 
+
+class CertificadoDigital(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    usuario_id = db.Column(db.Integer, db.ForeignKey('usuario.id'), nullable=False)
+    numero_serie = db.Column(db.String(128), unique=True, nullable=False)
+    alias = db.Column(db.String(128), nullable=True)
+    password_hash = db.Column(db.String(128), nullable=False)
+    fecha_registro = db.Column(db.DateTime, default=datetime.utcnow)
+
+    usuario = relationship('Usuario', backref=db.backref('certificados_digitales', lazy=True))
+
+    def establecer_clave(self, clave_privada):
+        self.password_hash = generate_password_hash(clave_privada)
+
+    def verificar_clave(self, clave_privada):
+        return check_password_hash(self.password_hash, clave_privada)
+
 # Tabla de playlist
 class Playlist(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/static/css/estilos.css
+++ b/static/css/estilos.css
@@ -1,0 +1,214 @@
+:root {
+  --color-background: #120626;
+  --color-surface: #1b0d36;
+  --color-surface-alt: #241043;
+  --color-accent: #7b4dff;
+  --color-accent-soft: #a37bff;
+  --color-text-primary: #f8f5ff;
+  --color-text-secondary: #c7b7e5;
+  --color-border: rgba(255, 255, 255, 0.08);
+  --color-border-strong: rgba(123, 77, 255, 0.4);
+  --shadow-soft: 0 20px 35px rgba(18, 6, 38, 0.35);
+  --radius-lg: 22px;
+  --radius-md: 14px;
+  --radius-sm: 8px;
+}
+
+body {
+  font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  background-color: var(--color-background);
+  color: var(--color-text-primary);
+  margin: 0;
+  min-height: 100vh;
+}
+
+a {
+  color: var(--color-accent-soft);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--color-accent);
+}
+
+.auth-wrapper {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: stretch;
+}
+
+.auth-card {
+  background: linear-gradient(160deg, rgba(36, 16, 67, 0.96), rgba(27, 13, 54, 0.9));
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  padding: 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.auth-card--highlight {
+  background: linear-gradient(155deg, rgba(123, 77, 255, 0.15), rgba(18, 6, 38, 0.9));
+  border: 1px solid var(--color-border-strong);
+}
+
+.auth-card h1,
+.auth-card h2 {
+  margin: 0;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.auth-card p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.auth-form label {
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}
+
+.auth-input,
+.auth-select,
+.auth-textarea {
+  background: rgba(18, 6, 38, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-md);
+  padding: 0.85rem 1rem;
+  color: var(--color-text-primary);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-input:focus,
+.auth-select:focus,
+.auth-textarea:focus {
+  outline: none;
+  border-color: var(--color-accent-soft);
+  box-shadow: 0 0 0 3px rgba(123, 77, 255, 0.25);
+}
+
+.auth-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}
+
+.auth-checkbox input {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--color-accent);
+}
+
+.btn {
+  border-radius: var(--radius-md);
+  border: none;
+  padding: 0.85rem 1.4rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  text-align: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.btn:focus-visible {
+  outline: 3px solid rgba(123, 77, 255, 0.35);
+  outline-offset: 2px;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, var(--color-accent), #5829ff);
+  color: #fff;
+  box-shadow: 0 12px 24px rgba(123, 77, 255, 0.35);
+}
+
+.btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px rgba(123, 77, 255, 0.45);
+}
+
+.btn-outline {
+  background: rgba(18, 6, 38, 0.55);
+  border: 1px solid var(--color-border-strong);
+  color: var(--color-accent-soft);
+}
+
+.btn-outline:hover {
+  transform: translateY(-2px);
+  color: #fff;
+  box-shadow: 0 16px 30px rgba(123, 77, 255, 0.25);
+}
+
+.full-width {
+  width: 100%;
+}
+
+.auth-divider {
+  position: relative;
+  text-align: center;
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+}
+
+.auth-divider::before,
+.auth-divider::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  width: 40%;
+  height: 1px;
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.auth-divider::before {
+  left: 0;
+}
+
+.auth-divider::after {
+  right: 0;
+}
+
+.auth-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  align-items: center;
+}
+
+.link-muted {
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}
+
+.link-muted:hover {
+  color: #fff;
+}
+
+.helper-text {
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+@media (max-width: 640px) {
+  .auth-card {
+    padding: 1.8rem;
+  }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>{% block titulo %}DovahCloud{% endblock %}</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/estilos.css') }}">
+    <link rel="stylesheet" href="{{ url_for('serve_design_asset', filename='css/estilos.css') }}">
 </head>
 <body>
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -3,15 +3,32 @@
 {% block titulo %}Iniciar sesión{% endblock %}
 
 {% block contenido %}
-<h1>🔐 Iniciar sesión</h1>
+<div class="auth-wrapper">
+  <section class="auth-card">
+    <h1>🔐 Iniciar sesión con cuenta local</h1>
+    <p class="helper-text">Usa tu usuario y contraseña propios cuando no dispongas de acceso con Google.</p>
+    <form method="POST" class="auth-form">
+      <label for="nombre">Usuario</label>
+      <input class="auth-input" type="text" name="nombre" id="nombre" required>
 
-<form method="POST">
-  <label for="nombre">Usuario:</label><br>
-  <input type="text" name="nombre" required><br><br>
+      <label for="contraseña">Contraseña</label>
+      <input class="auth-input" type="password" name="contraseña" id="contraseña" required>
 
-  <label for="contraseña">Contraseña:</label><br>
-  <input type="password" name="contraseña" required><br><br>
+      <button type="submit" class="btn btn-primary full-width">👉 Entrar</button>
+    </form>
+  </section>
 
-  <button type="submit">👉 Entrar</button>
-</form>
+  <section class="auth-card auth-card--highlight">
+    <h2>✨ Otras formas de acceso</h2>
+    <p>¿No puedes iniciar sesión con Google? Crea una cuenta local en segundos o utiliza tu certificado digital.</p>
+
+    <a href="{{ url_for('registro') }}" class="btn btn-primary full-width">📝 Crear cuenta local</a>
+
+    <div class="auth-divider">o</div>
+
+    <a href="{{ url_for('login_certificado') }}" class="btn btn-outline full-width">🔏 Entrar con certificado digital</a>
+
+    <p class="helper-text">¿Aún no tienes tu certificado vinculado? <a href="{{ url_for('registro_certificado') }}">Regístralo aquí</a>.</p>
+  </section>
+</div>
 {% endblock %}

--- a/templates/login_certificado.html
+++ b/templates/login_certificado.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block titulo %}Iniciar sesión con certificado{% endblock %}
+
+{% block contenido %}
+<div class="auth-wrapper">
+  <section class="auth-card">
+    <h1>🔏 Accede con tu certificado digital</h1>
+    <p class="helper-text">Introduce el número de serie del certificado y su contraseña privada para iniciar sesión de manera segura.</p>
+
+    <form method="POST" class="auth-form">
+      <label for="numero_serie">Número de serie del certificado</label>
+      <input class="auth-input" type="text" name="numero_serie" id="numero_serie" required>
+
+      <label for="clave_privada">Contraseña privada</label>
+      <input class="auth-input" type="password" name="clave_privada" id="clave_privada" required>
+
+      <button type="submit" class="btn btn-primary full-width">Acceder con certificado</button>
+    </form>
+
+    <div class="auth-actions">
+      <a href="{{ url_for('registro_certificado') }}" class="btn btn-outline">Registrar un nuevo certificado</a>
+      <a href="{{ url_for('login') }}" class="link-muted">Volver al inicio de sesión clásico</a>
+    </div>
+  </section>
+</div>
+{% endblock %}

--- a/templates/registro.html
+++ b/templates/registro.html
@@ -3,28 +3,38 @@
 {% block titulo %}Registro de usuario{% endblock %}
 
 {% block contenido %}
-<h1>👤 Crear nuevo usuario</h1>
+<div class="auth-wrapper">
+  <section class="auth-card">
+    <h1>👤 Crear nuevo usuario local</h1>
+    <p class="helper-text">Crea una cuenta tradicional para acceder cuando no tengas disponible el inicio de sesión con Google.</p>
+    <form method="POST" class="auth-form">
+      <label for="nombre">Nombre de usuario</label>
+      <input class="auth-input" type="text" name="nombre" id="nombre" required>
 
-<form method="POST">
-  <label for="nombre">Nombre de usuario:</label><br>
-  <input type="text" name="nombre" required><br><br>
+      <label for="contraseña">Contraseña</label>
+      <input class="auth-input" type="password" name="contraseña" id="contraseña" required>
 
-  <label for="contraseña">Contraseña:</label><br>
-  <input type="password" name="contraseña" required><br><br>
+      <label for="avatar">Selecciona un avatar</label>
+      <select class="auth-select" name="avatar" id="avatar">
+        {% for avatar in avatars %}
+          <option value="{{ avatar.valor }}">{{ avatar.etiqueta }}</option>
+        {% endfor %}
+      </select>
 
-  <label for="avatar">Selecciona un avatar:</label><br>
-  <select name="avatar">
-    <option value="default_avatar.png">🐉 Default</option>
-    <option value="dragon.png">🔥 Dragón</option>
-    <option value="hielo.png">❄️ Hielo</option>
-    <option value="sombra.png">🌑 Sombra</option>
-  </select><br><br>
+      <label class="auth-checkbox">
+        <input type="checkbox" name="acceso_privado" value="1">
+        Conceder acceso a zona privada
+      </label>
 
-  <label>
-    <input type="checkbox" name="acceso_privado" value="1">
-    Conceder acceso a zona privada
-  </label><br><br>
+      <button type="submit" class="btn btn-primary full-width">🪄 Crear cuenta</button>
+    </form>
+  </section>
 
-  <button type="submit">🪄 Crear cuenta</button>
-</form>
+  <section class="auth-card auth-card--highlight">
+    <h2>🔏 Vincula tu certificado digital</h2>
+    <p>Registra tu certificado con una contraseña privada para acceder de forma segura y sin recordar credenciales adicionales.</p>
+    <a href="{{ url_for('registro_certificado') }}" class="btn btn-outline full-width">Registrar certificado digital</a>
+    <p class="helper-text">¿Ya tienes un certificado registrado? <a href="{{ url_for('login_certificado') }}">Inicia sesión aquí</a>.</p>
+  </section>
+</div>
 {% endblock %}

--- a/templates/registro_certificado.html
+++ b/templates/registro_certificado.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+
+{% block titulo %}Registrar certificado digital{% endblock %}
+
+{% block contenido %}
+<div class="auth-wrapper">
+  <section class="auth-card">
+    <h1>🛡️ Registrar certificado digital</h1>
+    <p class="helper-text">Vincula tu certificado electrónico con una contraseña privada para acceder rápidamente a DovahCloud.</p>
+
+    <form method="POST" class="auth-form">
+      <label for="nombre">Nombre de usuario</label>
+      <input class="auth-input" type="text" name="nombre" id="nombre" placeholder="Usuario nuevo o existente" required>
+
+      <label for="numero_serie">Número de serie del certificado</label>
+      <input class="auth-input" type="text" name="numero_serie" id="numero_serie" required>
+
+      <label for="alias">Alias del certificado (opcional)</label>
+      <input class="auth-input" type="text" name="alias" id="alias" placeholder="Certificado empresa / personal">
+
+      <label for="clave_privada">Contraseña privada del certificado</label>
+      <input class="auth-input" type="password" name="clave_privada" id="clave_privada" required>
+
+      <label for="contraseña_local">Contraseña local de respaldo</label>
+      <input class="auth-input" type="password" name="contraseña_local" id="contraseña_local" placeholder="Requerida para usuarios nuevos">
+
+      <label for="avatar">Selecciona un avatar</label>
+      <select class="auth-select" name="avatar" id="avatar">
+        {% for avatar in avatars %}
+          <option value="{{ avatar.valor }}">{{ avatar.etiqueta }}</option>
+        {% endfor %}
+      </select>
+
+      <label class="auth-checkbox">
+        <input type="checkbox" name="acceso_privado" value="1">
+        Conceder acceso a zona privada
+      </label>
+
+      <button type="submit" class="btn btn-primary full-width">Registrar certificado</button>
+    </form>
+
+    <p class="helper-text">Si el usuario ya existe, el certificado quedará vinculado sin crear una cuenta nueva.</p>
+
+    <div class="auth-actions">
+      <a href="{{ url_for('login_certificado') }}" class="btn btn-outline">Iniciar sesión con certificado</a>
+      <a href="{{ url_for('registro') }}" class="link-muted">Prefiero registrarme con usuario y contraseña</a>
+    </div>
+  </section>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add backend support for registering and authenticating with digital certificates alongside local accounts
- refresh the login and registration templates with purple-themed actions and links to the new certificate flows
- add a shared auth stylesheet to unify buttons and layouts across the new and existing forms

## Testing
- python -m compileall app.py models.py

------
https://chatgpt.com/codex/tasks/task_e_68e64a11f32c832b996e163d60bcd2dd